### PR TITLE
Remove rules which don't work on Ubuntu 12.04.3

### DIFF
--- a/files/etc/audit/audit.rules
+++ b/files/etc/audit/audit.rules
@@ -30,17 +30,19 @@
 -w /sbin/auditd -p x -k audittools
 
 ## special files
--a entry,always -F arch=b32 -S mknod -S mknodat -k specialfiles
--a entry,always -F arch=b64 -S mknod -S mknodat -k specialfiles
+# FIXME: https://github.com/gds-operations/puppet-auditd/issues/1
+#-a entry,always -F arch=b32 -S mknod -S mknodat -k specialfiles
+#-a entry,always -F arch=b64 -S mknod -S mknodat -k specialfiles
 
 ## Mount operations
--a entry,always -F arch=b32 -S mount -S umount -S umount2 -k mount
--a entry,always -F arch=b64 -S mount -S umount2 -k mount 
+# FIXME: https://github.com/gds-operations/puppet-auditd/issues/1
+#-a entry,always -F arch=b32 -S mount -S umount -S umount2 -k mount
+#-a entry,always -F arch=b64 -S mount -S umount2 -k mount 
 
 ## changes to the time
-##
--a entry,always -F arch=b32 -S adjtimex -S settimeofday -S clock_settime -k time
--a entry,always -F arch=b64 -S adjtimex -S settimeofday -S clock_settime -k time
+# FIXME: https://github.com/gds-operations/puppet-auditd/issues/1
+#-a entry,always -F arch=b32 -S adjtimex -S settimeofday -S clock_settime -k time
+#-a entry,always -F arch=b64 -S adjtimex -S settimeofday -S clock_settime -k time
 
 ## Use stunnel
 -w /usr/sbin/stunnel -p x -k stunnel
@@ -120,28 +122,31 @@
 -w /etc/ssh/sshd_config -k sshd
 
 ## changes to hostname
--a exit,always -F arch=b32 -S sethostname -k hostname
--a exit,always -F arch=b64 -S sethostname -k hostname
+# FIXME: https://github.com/gds-operations/puppet-auditd/issues/1
+#-a exit,always -F arch=b32 -S sethostname -k hostname
+#-a exit,always -F arch=b64 -S sethostname -k hostname
 
 ## changes to issue
 -w /etc/issue -p wa -k etcissue
 -w /etc/issue.net -p wa -k etcissue
 
 ## this was to noisy currently.
+# FIXME: https://github.com/gds-operations/puppet-auditd/issues/1
 ## log all commands executed by an effective id of 0 aka root.
 ## -a exit,always -F arch=b64 -F euid=0 -S execve -k rootcmd
 ## -a exit,always -F arch=b32 -F euid=0 -S execve -k rootcmd
 
 ## Capture all failures to access on critical elements
--a exit,always -F arch=b64 -S open -F dir=/etc -F success=0 -k unauthedfileacess
--a exit,always -F arch=b64 -S open -F dir=/bin -F success=0 -k unauthedfileacess
--a exit,always -F arch=b64 -S open -F dir=/sbin -F success=0 -k unauthedfileacess
--a exit,always -F arch=b64 -S open -F dir=/usr/bin -F success=0 -k unauthedfileacess
--a exit,always -F arch=b64 -S open -F dir=/usr/sbin -F success=0 -k unauthedfileacess
--a exit,always -F arch=b64 -S open -F dir=/var -F success=0 -k unauthedfileacess
--a exit,always -F arch=b64 -S open -F dir=/home -F success=0 -k unauthedfileacess
--a exit,always -F arch=b64 -S open -F dir=/data -F success=0 -k unauthedfileacess
--a exit,always -F arch=b64 -S open -F dir=/srv -F success=0 -k unauthedfileacess
+# FIXME: https://github.com/gds-operations/puppet-auditd/issues/1
+#-a exit,always -F arch=b64 -S open -F dir=/etc -F success=0 -k unauthedfileacess
+#-a exit,always -F arch=b64 -S open -F dir=/bin -F success=0 -k unauthedfileacess
+#-a exit,always -F arch=b64 -S open -F dir=/sbin -F success=0 -k unauthedfileacess
+#-a exit,always -F arch=b64 -S open -F dir=/usr/bin -F success=0 -k unauthedfileacess
+#-a exit,always -F arch=b64 -S open -F dir=/usr/sbin -F success=0 -k unauthedfileacess
+#-a exit,always -F arch=b64 -S open -F dir=/var -F success=0 -k unauthedfileacess
+#-a exit,always -F arch=b64 -S open -F dir=/home -F success=0 -k unauthedfileacess
+#-a exit,always -F arch=b64 -S open -F dir=/data -F success=0 -k unauthedfileacess
+#-a exit,always -F arch=b64 -S open -F dir=/srv -F success=0 -k unauthedfileacess
 
 ## Monitor for use of process ID change (switching accounts) applications
 -w /bin/su -p x -k priv_esc


### PR DESCRIPTION
```
ssharpe@ qa-jump-1:~$ sudo service auditd restart

    Restarting audit daemon auditd Error sending add rule data request (Invalid argument)
    There was an error in line 33 of /etc/audit/audit.rules
    [ OK ]
```

https://bugs.launchpad.net/ubuntu/+source/audit/+bug/1158500

This seems to imply that the syscall table is out of sync between Precise and the kernel installed by Ubuntu with 12.04.3

The syscalls are provided by the linux-libc-dev package:
http://packages.ubuntu.com/search?keywords=linux-libc-dev

There is no installable package for Precise I can find which has a matching syscall table to the lts-raring kernel. ARRGGHHH.
