### PR TITLE
Change package name for libaudit based on release

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -7,11 +7,12 @@ class auditd::package {
     ensure => installed
   }
 
-  $pkgname = $lsbdistrelease ? {
-    '12.04' => 'libaudit0',
-    default => 'libaudit1',
+  $pkgname = $::lsbdistcodename ? {
+    /^lucid$|^precise$/ => 'libaudit0',
+    'trusty'            => 'libaudit1',
+    default             => 'libaudit1',
   }
-  package { "$pkgname":
+  package { $pkgname:
     ensure => installed
   }
   package { 'audispd-plugins':

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -1,7 +1,28 @@
 require 'spec_helper'
 
 describe 'auditd::package' do
-  it { should contain_package('auditd') }
-  it { should contain_package('libaudit0') }
-  it { should contain_package('audispd-plugins') }
+  context "default" do
+    let (:facts) {{ :lsbdistcodename => 'saucy' }}
+    it { should contain_package('auditd') }
+    it { should contain_package('libaudit1') }
+    it { should contain_package('audispd-plugins') }
+  end
+  context "ubuntu lucid" do
+    let (:facts) {{ :lsbdistcodename => 'lucid' }}
+    it { should contain_package('auditd') }
+    it { should contain_package('libaudit0') }
+    it { should contain_package('audispd-plugins') }
+  end
+  context "ubuntu precise" do
+    let (:facts) {{ :lsbdistcodename => 'precise' }}
+    it { should contain_package('auditd') }
+    it { should contain_package('libaudit0') }
+    it { should contain_package('audispd-plugins') }
+  end
+  context "ubuntu trusty" do
+    let (:facts) {{ :lsbdistcodename => 'trusty' }}
+    it { should contain_package('auditd') }
+    it { should contain_package('libaudit1') }
+    it { should contain_package('audispd-plugins') }
+  end
 end


### PR DESCRIPTION
Post 12.04 Ubuntu changed the name of the libaudit package. Specify which
package name for all current LTS releases and set a default for non LTS
releases.

Thanks to @damoxc for contributing the original patch.
