### PR TITLE
Test puppet 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.4.0"
 # Only notify for failed builds.
 notifications:
   email:


### PR DESCRIPTION
Since we use puppet 3.4 we should probably test our modules work with it.
