### PR TITLE
Remove /data watch default

### DIFF
--- a/templates/audit.rules.begin.fragment.erb
+++ b/templates/audit.rules.begin.fragment.erb
@@ -140,7 +140,6 @@
 -a exit,always -F arch=b64 -S open -F dir=/usr/sbin -F success=0 -k unauthedfileacess
 -a exit,always -F arch=b64 -S open -F dir=/var -F success=0 -k unauthedfileacess
 -a exit,always -F arch=b64 -S open -F dir=/home -F success=0 -k unauthedfileacess
--a exit,always -F arch=b64 -S open -F dir=/data -F success=0 -k unauthedfileacess
 -a exit,always -F arch=b64 -S open -F dir=/srv -F success=0 -k unauthedfileacess
 
 ## Monitor for use of process ID change (switching accounts) applications


### PR DESCRIPTION
auditd fails to load with:

Error sending add rule data request (No such file or directory)
There was an error in line 143 of /etc/audit/audit.rules

...if the /data directory doesn't exist (as it doesn't on Ubuntu default). This can be easily added back in with the source option in the hiera-support branch.
