### PR TITLE
Publish version 0.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+2014-11-24 Release 0.3.0 - various fixes by https://github.com/jpds
+- Watch apparmor config
+- Watch access to /home by admins
+- Watch ipsec config
+- Watch strongswan config
+- Watch modules loading and unloading
+- Watch files and execution in /tmp
+- Watch timezone changes
+- Entry rules deprecated in favour of exit rules
+- Removed /data from default watch list
+
 2014-5-20 Release 0.2.0
 - Support versions of Ubuntu greater than 12.04
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'gdsoperations-auditd'
-version       '0.2.0'
+version       '0.3.0'
 source        'https://github.com/gds-operations/puppet-auditd'
 author        'Government Digital Service'
 license       'MIT'


### PR DESCRIPTION
This version contains many many fixes and improvements by @jpds
- Watch apparmor config (#10)
- Watch access to /home by admins (#19,#20)
- Watch ipsec config (#16)
- Watch strongswan config (#16)
- Watch modules loading and unloading (#22)
- Watch files and execution in /tmp (#21)
- Watch timezone changes (#8)
- Entry rules deprecated in favour of exit rules (#13)
- Removed /data from default watch list (#23)

Full diff: https://github.com/gds-operations/puppet-auditd/compare/v0.2.0...release-0.3.0
