### PR TITLE
Change the expectation syntax for Rspec Puppet 2.x

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2013 Government Digital Service
+Copyright (c) 2013 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -25,7 +25,7 @@ describe 'auditd' do
         :concat_basedir  => '/var/lib/puppet/concat',
       }}
 
-      it { expect { should }.to raise_error(Puppet::Error, /Nexenta not supported/) }
+      it { should raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
 end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -6,7 +6,7 @@ describe 'auditd::package' do
         :osfamily        => 'Solaris',
         :operatingsystem => 'Nexenta',
     }}
-    it { expect { should }.to raise_error(Puppet::Error, /Nexenta not supported/) }
+    it { should raise_error(Puppet::Error, /Nexenta not supported/) }
   end
 
   context "ubuntu lucid" do


### PR DESCRIPTION
Fix the failing tests found in #25 and correct the Copyright notice.

Rspec Puppet version 2 changed the supported syntax for checking
exceptions:

rodjek/rspec-puppet@8459e14

>  The construct I had been using to check for exceptions in negative
>  tests broke. expect { should }.to raise_error(...) had to be replaced
>  with should raise_error(...)