### PR TITLE
Add os_support information to improve the Metadata Quality Score

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
     },
     {
     "operatingsystem": "Ubuntu",
-    "operatingsystemrelease": [ "12.04" ]
+    "operatingsystemrelease": [ "12.04", "14.04" ]
     },
     {
     "operatingsystem": "Debian"

--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,18 @@
   "license": "MIT",
   "summary": "Manage auditd for Ubuntu",
   "source": "https://github.com/gds-operations/puppet-auditd",
+  "operatingsystem_support": [
+    {
+    "operatingsystem": "RedHat"
+    },
+    {
+    "operatingsystem": "Ubuntu",
+    "operatingsystemrelease": [ "12.04" ]
+    },
+    {
+    "operatingsystem": "Debian"
+    }
+  ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">=1.0.0 <=1.2.1" }


### PR DESCRIPTION
According to the Metadata Quality results on Puppet Forge, there is an error in the metadata because it does not contain os_support information. This PR will fix that.
The operating systems and releases are based on information I've found in the source and changelog.