### PR TITLE
Use the container based infrastructure for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ env:
 notifications:
   email:
     on_success: never
+sudo: false


### PR DESCRIPTION
We don't use sudo so can use the new container based infrastructure that
travis now provides.

http://docs.travis-ci.com/user/migrating-from-legacy