### PR TITLE
Increasing pinned version of concat to <3.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "gdsoperations-auditd",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Government Digital Service",
   "license": "MIT",
   "summary": "Manage auditd for Ubuntu",
@@ -19,7 +19,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">=1.0.0 <2.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=1.0.0 <3.0.0" }
   ],
   "project_page": "https://github.com/gds-operations/puppet-auditd"
 }


### PR DESCRIPTION
Current version of concat is 2.2.0 - although this is a major re-implementation, it does not seem to have any breaking changes, so I have relaxed the pinned version requirements to support versions <3.0.0. I have other modules that require >2.1.0, so this will resolve the conflict.