### PR TITLE
Update puppet and ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
       rvm: 2.4.0
   allow_failures:
     - env: PUPPET_VERSION=">= 0"
+    - env: PUPPET_VERSION="~> 4.8.0"
 # Only notify for failed builds.
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,24 @@ language: ruby
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 rvm:
-  - 1.8.7
   - 1.9.3
+  - 2.1.6
+  - 2.3.3
+  - 2.4.0
 env:
-  matrix:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.8.7"
+  - PUPPET_VERSION="~> 4.8.0"
+  - PUPPET_VERSION=">= 0"
+matrix:
+  exclude:
+    - env: PUPPET_VERSION="~> 3.8.7"
+      rvm: 2.2.6
+    - env: PUPPET_VERSION="~> 3.8.7"
+      rvm: 2.3.3
+    - env: PUPPET_VERSION="~> 3.8.7"
+      rvm: 2.4.0
+  allow_failures:
+    - env: PUPPET_VERSION=">= 0"
 # Only notify for failed builds.
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
 
 gem 'rake', '10.4.2'
 gem 'puppet-lint', '1.1.0'
-gem 'rspec-puppet', '2.0.0'
+gem 'rspec-puppet', '2.1.0'
 gem 'rspec-system-puppet', '2.2.1'
 gem 'puppetlabs_spec_helper', '0.8.2'
 gem 'puppet-syntax', '1.4.1'


### PR DESCRIPTION
No longer run tests against ruby 1.8.7 and old versions of puppet.
Run tests on more modern rubies and versions of puppet.
Also exclude puppet 3.8.7 on newer versions of ruby.

Will help with getting #40 merged